### PR TITLE
Delegate saving and updating EntityModel to EntityModels rather than to Controllers.

### DIFF
--- a/OpERP/src/main/java/devopsdistilled/operp/client/abstracts/AbstractEntityModel.java
+++ b/OpERP/src/main/java/devopsdistilled/operp/client/abstracts/AbstractEntityModel.java
@@ -57,4 +57,10 @@ public abstract class AbstractEntityModel<E extends Entiti, ES extends EntitySer
 		return methods[0];
 	}
 
+	@Override
+	public E saveAndUpdateModel(E entity) {
+		E savedEntity = getService().saveAndFlush(entity);
+		update();
+		return savedEntity;
+	}
 }

--- a/OpERP/src/main/java/devopsdistilled/operp/client/abstracts/EntityModel.java
+++ b/OpERP/src/main/java/devopsdistilled/operp/client/abstracts/EntityModel.java
@@ -14,5 +14,7 @@ public interface EntityModel<E extends Entiti, ES extends EntityService<E, ID>, 
 	void setEntities(List<E> entities);
 
 	public ES getService();
+	
+	public E saveAndUpdateModel(E entity);
 
 }

--- a/OpERP/src/main/java/devopsdistilled/operp/client/items/controllers/impl/CreateItemPaneControllerImpl.java
+++ b/OpERP/src/main/java/devopsdistilled/operp/client/items/controllers/impl/CreateItemPaneControllerImpl.java
@@ -55,9 +55,7 @@ public class CreateItemPaneControllerImpl implements CreateItemPaneController {
 
 	@Override
 	public Item save(Item item) {
-		Item savedItem = itemModel.getService().saveAndFlush(item);
-		itemModel.update(); // update ItemModel and notify observers about new
-							// item
+		Item savedItem = itemModel.saveAndUpdateModel(item);
 		return savedItem;
 	}
 }

--- a/OpERP/src/test/java/devopsdistilled/operp/client/items/model/ItemModelTest.java
+++ b/OpERP/src/test/java/devopsdistilled/operp/client/items/model/ItemModelTest.java
@@ -1,0 +1,51 @@
+package devopsdistilled.operp.client.items.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import devopsdistilled.operp.client.context.AppContext;
+import devopsdistilled.operp.client.items.models.ItemModel;
+import devopsdistilled.operp.server.data.entity.items.Item;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { AppContext.class })
+public class ItemModelTest {
+
+	@Inject
+	private ItemModel itemModel;
+
+	private Item item;
+
+	@Before
+	public void setUp() throws Exception {
+		item = new Item();
+
+		assertNotNull(itemModel);
+	}
+
+	@Test
+	public void testSaveAndUpdateModel() {
+
+		// This test won't run if Unique constraints are set in Item Entity.
+		// Unique Constraints were removed to test this Test.
+
+		itemModel.update();
+		int initialItemsSize = itemModel.getEntities().size();
+		item.setItemName("Test Item");
+		Item savedItem = itemModel.saveAndUpdateModel(item);
+		assertNotNull(savedItem);
+		System.out.println(savedItem.getItemId());
+		int afterUpdateSize = itemModel.getEntities().size();
+		// assertThat(initialItemsSize, is(afterUpdateSize - 1));
+		assertEquals(new Long(initialItemsSize), new Long(afterUpdateSize - 1));
+	}
+
+}


### PR DESCRIPTION
EntityModel.saveAndUpdateModel(Entity entity) is added which save entity and update the model.

Also, test for the method is added.
